### PR TITLE
fix adjustment to Events < MIN_DURATION_MINUTES

### DIFF
--- a/tachyon/src/main/java/com/linkedin/android/tachyon/DayView.java
+++ b/tachyon/src/main/java/com/linkedin/android/tachyon/DayView.java
@@ -499,10 +499,11 @@ public class DayView extends ViewGroup {
             EventColumnSpan columnSpan = eventColumnSpansHelper.columnSpans.get(i);
 
             int filteredStartMinute = Math.max(startMinute, timeRange.startMinute);
-            int duration = Math.min(endMinute, timeRange.endMinute) - filteredStartMinute;
+            int filteredEndMinute = Math.min(endMinute, timeRange.endMinute);
+            int duration = filteredEndMinute - filteredStartMinute;
             if (duration < MIN_DURATION_MINUTES) {
                 duration = MIN_DURATION_MINUTES;
-                filteredStartMinute = endMinute - duration;
+                filteredStartMinute = filteredEndMinute - duration;
             }
 
             int start = columnSpan.startColumn * eventColumnWidth + dividerStart + eventMargin;


### PR DESCRIPTION
I reported this bug here:
https://github.com/linkedin/Tachyon/issues/12

It seemed like a simple enough fix, so I took a stab at it. With this change, I am seeing the problem event drawn in the correct place